### PR TITLE
feat(logging): structured JSON logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Four main classes in `src/main/kotlin/com/github/zzave/ynabsplitpayeeandmemo/`:
 
 CLI options can also be set via environment variables: `YNAB_TOKEN`, `YNAB_BUDGET_ID`, `YNAB_BUDGET_IDS`, `YNAB_ACCOUNT_ID`. A `.env` file is used by `make run` / `make dry-run`.
 
-Logging is controlled by `YNAB_LOG` env var (`FILE` for file output, otherwise console). Config in `src/main/resources/logback.xml`.
+Logging is controlled by two env vars. `YNAB_LOG` sets the destination (`FILE` for file output, otherwise console). `YNAB_LOG_FORMAT` sets the format (`plain` for human-readable text, otherwise JSON via logstash-logback-encoder). Config in `src/main/resources/logback.xml`.
 
 ## Testing Infrastructure
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,6 +102,7 @@ dependencies {
     // Logging with SLF4J and Logback
     implementation(libs.logback)
     implementation(libs.janino)
+    implementation(libs.logstash.logback.encoder)
 
     // Kotlinx DateTime
     implementation(libs.kotlinx.datetime)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ kotlinxDatetime = "0.7.1"
 kotlinxSerialization = "1.10.0"
 ktor = "3.4.0"
 logback = "1.5.32"
+logstash-logback-encoder = "8.0"
 kotest = "6.1.4"
 shadow = "9.3.2"
 wiremock = "3.10.0"
@@ -27,6 +28,7 @@ ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref =
 ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
 ktor-serialization-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 logback = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback" }
+logstash-logback-encoder = { group = "net.logstash.logback", name = "logstash-logback-encoder", version.ref = "logstash-logback-encoder" }
 wiremock = { group = "org.wiremock", name = "wiremock-standalone", version.ref = "wiremock" }
 
 [plugins]

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,15 +1,32 @@
 <configuration>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+
+    <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <appender name="STDOUT_PLAIN" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} %-5level --- [%15.15thread] %-40.40logger{39} : %msg%n</pattern>
         </encoder>
     </appender>
 
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <!-- The log file will be created inside the container at /app/logs/ -->
+    <appender name="FILE_JSON" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>./logs/ynab-split-payee-and-memo.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>test.%i.log</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>1</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>5MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
 
+    <appender name="FILE_PLAIN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>./logs/ynab-split-payee-and-memo.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
             <fileNamePattern>test.%i.log</fileNamePattern>
             <minIndex>1</minIndex>
@@ -25,14 +42,24 @@
 
     <if condition='"FILE".equalsIgnoreCase(property("YNAB_LOG"))'>
         <then>
-            <root level="info">
-                <appender-ref ref="FILE"/>
-            </root>
+            <if condition='"plain".equalsIgnoreCase(property("YNAB_LOG_FORMAT"))'>
+                <then>
+                    <root level="info"><appender-ref ref="FILE_PLAIN"/></root>
+                </then>
+                <else>
+                    <root level="info"><appender-ref ref="FILE_JSON"/></root>
+                </else>
+            </if>
         </then>
         <else>
-            <root level="info">
-                <appender-ref ref="STDOUT"/>
-            </root>
+            <if condition='"plain".equalsIgnoreCase(property("YNAB_LOG_FORMAT"))'>
+                <then>
+                    <root level="info"><appender-ref ref="STDOUT_PLAIN"/></root>
+                </then>
+                <else>
+                    <root level="info"><appender-ref ref="STDOUT_JSON"/></root>
+                </else>
+            </if>
         </else>
     </if>
 


### PR DESCRIPTION
## Summary
- Add `logstash-logback-encoder` dependency for JSON log output
- Default log format is now JSON (structured, machine-readable)
- New `YNAB_LOG_FORMAT=plain` env var restores the previous human-readable pattern format
- Existing `YNAB_LOG` env var (FILE vs console destination) is unchanged

## Test plan
- [x] Build passes: `make build`
- [x] Run with default (JSON): logs are valid JSON objects with `@timestamp`, `level`, `message` fields
- [x] Run with `YNAB_LOG_FORMAT=plain`: logs use the previous human-readable pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)