### PR TITLE
chore: improve Makefile help, harden Dockerfile, fix docker path in run script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 # First stage, build the application
 FROM eclipse-temurin:25.0.2_10-jdk-alpine AS build
+# Create a minimal system user for the build (no login shell, no sudo).
+# Home dir is required so Gradle can write its cache to ~/.gradle.
+RUN addgroup --system gradle \
+ && adduser --system --ingroup gradle --home /home/gradle gradle \
+ && mkdir -p /home/gradle/src \
+ && chown -R gradle:gradle /home/gradle
+USER gradle
 COPY --chown=gradle:gradle ./gradlew /home/gradle/src/
 WORKDIR /home/gradle/src
 COPY --chown=gradle:gradle gradle/ /home/gradle/src/gradle/

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,27 @@ dry-run: docker
 		--env-file .env \
 		--rm --name ynab-updater \
 		${docker_image_name}:${docker_image_version} --dry-run
+
+
+
+#	 This outputs any command in the Makefile. With a short description taken from a ## prefixed command after the command (preferred) or the line above
+#	 ## build the project
+#	 build:
+#    	<build command>
+#
+#    yolo: ## quick build of the project - with as little validation as possible
+#    	<yolo command>
+#
+help: ## Show this help
+
+	@echo "Usage: make <command>"; \
+	echo ""; \
+	desc=""; \
+	while IFS= read -r line; do \
+		case "$$line" in \
+			'## '*)              desc="$${line#\#\# }" ;; \
+			[a-zA-Z_-]*:[[:space:]]*'## '*) printf '\033[36m%-20s\033[0m %s\n' "$${line%%:*}" "$${line#*\#\# }"; desc="" ;; \
+			[a-zA-Z_-]*:|[a-zA-Z_-]*:[[:space:]]*) printf '\033[36m%-20s\033[0m %s\n' "$${line%%:*}" "$$desc"; desc="" ;; \
+			*)                   desc="" ;; \
+		esac; \
+	done < $(MAKEFILE_LIST) | sort

--- a/run-ynab-splitter.sh
+++ b/run-ynab-splitter.sh
@@ -2,6 +2,13 @@
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
+#path to docker executable
+# typicaly paths:
+#  /usr/local/bin/docker
+#  /opt/homebrew/bin/docker
+DOCKER_EXE=/opt/homebrew/bin/docker
+
+
 calculate_last_successful_run () {
     local LAST_SUCCESS="$1"
     local TIME_AGO="unknown time ago"
@@ -30,11 +37,11 @@ calculate_last_successful_run () {
 
 LOG_DIR="${SCRIPT_DIR}/logs"
 # Run the Docker container
-/usr/local/bin/docker run \
+$DOCKER_EXE run \
   -v "${LOG_DIR}:/app/logs" \
   --env-file "${SCRIPT_DIR}/.env" \
   --rm --name ynab-updater \
-  zzave/ynab-split-payee:0.0.1
+  zzave/ynab-split-payee:0.2.2
 
 RESULT="$?"
 if [ "$RESULT" -eq 0 ]; then


### PR DESCRIPTION
## Summary
- Add `make help` target with colour-coded output; supports `## description` annotations inline or on the preceding line
- Run Gradle build as a non-root system user inside the Docker image
- Make the Docker executable path configurable via `DOCKER_EXE` in `run-ynab-splitter.sh` and bump hardcoded image version to `0.2.2`

## Test Plan
- [x] `make test` passes
- [x] `make help` shows all targets without variable assignments leaking in

🤖 Generated with [Claude Code](https://claude.com/claude-code)