### PR TITLE
docs: add cloud setup page for Scaleway Serverless Jobs

### DIFF
--- a/docs/cloud.html
+++ b/docs/cloud.html
@@ -417,21 +417,6 @@
             line-height: 1.55;
         }
 
-        .cli-ref-meta {
-            font-size: 0.78rem;
-            color: var(--text-muted);
-            margin-top: 0.25rem;
-        }
-
-        .cli-ref-meta code {
-            font-family: var(--font-mono);
-            font-size: 0.75rem;
-            background: var(--code-bg);
-            padding: 0.1rem 0.4rem;
-            border-radius: 4px;
-            color: #d4a0ff;
-        }
-
         .tag {
             display: inline-block;
             font-size: 0.68rem;
@@ -447,11 +432,6 @@
         .tag-required {
             background: rgba(232, 72, 85, 0.12);
             color: var(--accent-red);
-        }
-
-        .tag-default {
-            background: rgba(84, 91, 254, 0.1);
-            color: var(--accent-purple);
         }
 
         /* Inline code */
@@ -594,12 +574,12 @@
         </div>
         <h2 id="prerequisites-heading">Prerequisites</h2>
         <p>
-            Before you start, make sure you have these two things in place.
+            Before you begin, make sure you have the following:
         </p>
 
         <ul class="checklist" role="list">
-            <li>A <strong>Scaleway account</strong> with a project in the Paris or Amsterdam region.</li>
-            <li>A <strong>YNAB Personal Access Token</strong>. If you don't have one yet, see <a href="usage.html#prerequisites">the usage guide</a> for how to create it.</li>
+            <li><span>A <strong>Scaleway account</strong> with a project in the Paris (<code>fr-par</code>) or Amsterdam (<code>nl-ams</code>) region.</span></li>
+            <li><span>A <strong>YNAB Personal Access Token</strong>. If you don't have one yet, follow the steps in the <a href="usage.html#prerequisites">Usage Guide</a>.</span></li>
         </ul>
     </section>
 
@@ -607,11 +587,12 @@
     <section class="tutorial-section" id="create-job" aria-labelledby="create-job-heading">
         <div class="section-badge">
             <div class="section-number" aria-hidden="true">2</div>
-            <span class="section-label">Set it up</span>
+            <span class="section-label">Setup</span>
         </div>
         <h2 id="create-job-heading">Create the job</h2>
         <p>
-            In the Scaleway Console, navigate to <strong>Serverless &rarr; Jobs</strong> and create a new job definition.
+            In the Scaleway Console, navigate to <strong>Serverless &rarr; Jobs</strong>
+            and click <strong>Create Job</strong>.
         </p>
         <p>
             Set the image source to the public Docker image:
@@ -621,7 +602,7 @@
         <div class="code-block"><code><span class="token-url">docker.io/zzave/ynab-split-payee:latest</span></code></div>
 
         <p>
-            For resources, <strong>1 vCPU</strong> and <strong>256 MB RAM</strong> is more than enough.
+            For resources, <strong>1 vCPU</strong> and <strong>256 MB RAM</strong> is plenty.
             The job typically finishes in a few seconds.
         </p>
     </section>
@@ -630,23 +611,23 @@
     <section class="tutorial-section" id="env-vars" aria-labelledby="env-vars-heading">
         <div class="section-badge">
             <div class="section-number" aria-hidden="true">3</div>
-            <span class="section-label">Configure</span>
+            <span class="section-label">Configuration</span>
         </div>
         <h2 id="env-vars-heading">Environment variables</h2>
         <p>
-            Add the following environment variables to your job definition.
+            Add these environment variables to the job definition.
             Only the token is required &mdash; the rest are optional.
         </p>
 
         <div class="cli-ref" role="list">
             <div class="cli-ref-item" role="listitem">
                 <div class="cli-ref-flags">YNAB_TOKEN <span class="tag tag-required">Required</span></div>
-                <div class="cli-ref-desc">Your YNAB Personal Access Token. This is how the tool authenticates with the YNAB API.</div>
+                <div class="cli-ref-desc">Your YNAB Personal Access Token. This is how the job authenticates with the YNAB API.</div>
             </div>
 
             <div class="cli-ref-item" role="listitem">
                 <div class="cli-ref-flags">YNAB_BUDGET_ID</div>
-                <div class="cli-ref-desc">Target a specific YNAB budget. If omitted, the tool uses your last-used budget.</div>
+                <div class="cli-ref-desc">Target a specific budget. If omitted, the job uses your last-used budget.</div>
             </div>
 
             <div class="cli-ref-item" role="listitem">
@@ -664,7 +645,7 @@
             <div class="callout-label">Tip</div>
             <p>
                 Use Scaleway's <strong>secret management</strong> to store your YNAB token
-                rather than adding it as a plain-text environment variable.
+                instead of adding it as a plain-text environment variable.
             </p>
         </div>
     </section>
@@ -673,24 +654,24 @@
     <section class="tutorial-section" id="cron-trigger" aria-labelledby="cron-trigger-heading">
         <div class="section-badge">
             <div class="section-number" aria-hidden="true">4</div>
-            <span class="section-label">Schedule</span>
+            <span class="section-label">Scheduling</span>
         </div>
         <h2 id="cron-trigger-heading">Cron trigger</h2>
         <p>
-            Add a cron trigger to your job so it runs automatically.
-            Every hour is a good default &mdash; frequent enough to catch new imports quickly,
-            light enough to stay well within free-tier limits.
+            Add a cron trigger to run the job on a schedule.
+            Every hour is a good default &mdash; it keeps your transactions tidy
+            without hitting YNAB's rate limits.
         </p>
 
         <p class="code-label">Cron expression (every hour)</p>
         <div class="code-block"><code><span class="token-arg">0 * * * *</span></code></div>
 
         <div class="callout callout-info" role="note">
-            <div class="callout-label">Note</div>
+            <div class="callout-label">Timezone</div>
             <p>
                 Scaleway cron triggers use <strong>UTC</strong>.
-                If you'd rather run it at a specific local time (e.g. every morning at 8 AM),
-                adjust the hour accordingly.
+                If you want to limit runs to your local business hours, adjust the
+                hour field accordingly.
             </p>
         </div>
     </section>
@@ -699,24 +680,27 @@
     <section class="tutorial-section" id="verify" aria-labelledby="verify-heading">
         <div class="section-badge">
             <div class="section-number" aria-hidden="true">5</div>
-            <span class="section-label">Confirm</span>
+            <span class="section-label">Confirm it works</span>
         </div>
         <h2 id="verify-heading">Verify</h2>
         <p>
-            Before relying on the schedule, trigger a manual run from the Scaleway console
-            to make sure everything is wired up correctly.
+            Before relying on the schedule, trigger a <strong>manual run</strong>
+            from the Scaleway console to make sure everything is wired up correctly.
         </p>
 
-        <ul class="checklist" role="list">
-            <li><strong>Trigger a manual run</strong> from the job detail page in the Scaleway console.</li>
-            <li><strong>Check the run log</strong> for exit code 0. If you see errors, double-check your token and environment variables.</li>
-            <li><strong>Open YNAB</strong> and confirm that your transactions were processed &mdash; payees should be clean, memos filled in.</li>
-        </ul>
+        <ol style="margin: 0.5rem 0 1.2rem 1.2rem; color: var(--text-secondary); display: grid; gap: 0.4rem;">
+            <li>Click <strong>"Run job"</strong> in the job detail page.</li>
+            <li>Wait for it to finish and check that the <strong>exit code is 0</strong> in the run log.</li>
+            <li>Open <strong>YNAB</strong> and confirm that your recent transactions have been processed &mdash; payees should be clean and memos populated.</li>
+        </ol>
 
-        <p>
-            Once the manual run looks good, the cron trigger will take care of the rest.
-            Your transactions will be cleaned up automatically, whether your laptop is on or not.
-        </p>
+        <div class="callout callout-tip" role="note">
+            <div class="callout-label">That's it</div>
+            <p>
+                Once the manual run succeeds, you're done. The cron trigger will take it from here &mdash;
+                your transactions will be cleaned up automatically, whether your laptop is on or not.
+            </p>
+        </div>
     </section>
 
     <!-- ===== FOOTER ===== -->

--- a/docs/cloud.html
+++ b/docs/cloud.html
@@ -1,0 +1,737 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cloud Setup - YNAB Split Payee and Memo</title>
+    <meta name="description" content="Run YNAB Split Payee and Memo as a scheduled cloud job with Scaleway Serverless Jobs.">
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Cpath d='M7 10C7 7.2 9.2 5 12 5L26 5 22 59 12 59C9.2 59 7 56.8 7 54Z' fill='%23545bfe' opacity='0.82'/%3E%3Cpath d='M38 5L52 5C54.8 5 57 7.2 57 10V54C57 56.8 54.8 59 52 59L42 59Z' fill='%23545bfe'/%3E%3Crect x='26.5' y='28.5' width='11' height='3.5' rx='1.75' fill='%232ec271'/%3E%3Crect x='11.5' y='16' width='12' height='2' rx='1' fill='%23fff' opacity='0.5'/%3E%3Crect x='11.5' y='22' width='8.5' height='2' rx='1' fill='%23fff' opacity='0.3'/%3E%3Crect x='12' y='36' width='10' height='2' rx='1' fill='%23fff' opacity='0.5'/%3E%3Crect x='12' y='42' width='7' height='2' rx='1' fill='%23fff' opacity='0.3'/%3E%3Crect x='42' y='16' width='11' height='2' rx='1' fill='%23fff' opacity='0.75'/%3E%3Crect x='42' y='22' width='8' height='2' rx='1' fill='%23fff' opacity='0.5'/%3E%3Crect x='42' y='36' width='10' height='2' rx='1' fill='%23fff' opacity='0.75'/%3E%3Crect x='42' y='42' width='6' height='2' rx='1' fill='%23fff' opacity='0.5'/%3E%3C/svg%3E">
+    <style>
+        /* ===== RESET & BASE ===== */
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+        :root {
+            --bg-dark: #181b2e;
+            --bg-dark-lighter: #1e2140;
+            --accent-purple: #545bfe;
+            --accent-purple-glow: rgba(84, 91, 254, 0.25);
+            --accent-green: #2ec271;
+            --accent-green-glow: rgba(46, 194, 113, 0.15);
+            --accent-red: #e84855;
+            --text-primary: #eef0f8;
+            --text-secondary: #a0a5c0;
+            --text-muted: #6b7194;
+            --code-bg: #12142a;
+            --font-stack: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+            --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'JetBrains Mono', Consolas, monospace;
+        }
+
+        body {
+            font-family: var(--font-stack);
+            background-color: var(--bg-dark);
+            color: var(--text-primary);
+            line-height: 1.6;
+            overflow-x: hidden;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+        }
+
+        /* ===== NOISE OVERLAY FOR TEXTURE ===== */
+        body::before {
+            content: '';
+            position: fixed;
+            top: 0; left: 0; right: 0; bottom: 0;
+            background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.03'/%3E%3C/svg%3E");
+            pointer-events: none;
+            z-index: 0;
+        }
+
+        /* ===== TOP NAV ===== */
+        .top-nav {
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            background: rgba(24, 27, 46, 0.92);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+            border-bottom: 1px solid rgba(84, 91, 254, 0.12);
+            padding: 0.75rem 2rem;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .top-nav a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            font-size: 0.9rem;
+            font-weight: 500;
+            transition: color 0.2s;
+        }
+
+        .top-nav a:hover { color: var(--accent-purple); }
+
+        .nav-back {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+        }
+
+        .nav-back svg {
+            width: 16px;
+            height: 16px;
+            fill: currentColor;
+            transition: transform 0.2s;
+        }
+
+        .nav-back:hover svg { transform: translateX(-3px); }
+
+        .nav-github {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+        }
+
+        .nav-github svg {
+            width: 18px;
+            height: 18px;
+            fill: currentColor;
+        }
+
+        /* ===== PAGE HEADER ===== */
+        .page-header {
+            position: relative;
+            z-index: 1;
+            text-align: center;
+            padding: 5rem 2rem 3.5rem;
+            overflow: hidden;
+        }
+
+        .page-header::before {
+            content: '';
+            position: absolute;
+            top: -50%; left: 50%; transform: translateX(-50%);
+            width: 700px; height: 700px;
+            background: radial-gradient(circle, var(--accent-purple-glow) 0%, transparent 65%);
+            pointer-events: none;
+        }
+
+        .page-header-content {
+            position: relative;
+            z-index: 2;
+            max-width: 720px;
+            margin: 0 auto;
+        }
+
+        .page-header h1 {
+            font-size: clamp(2rem, 4.5vw, 3rem);
+            font-weight: 800;
+            line-height: 1.15;
+            letter-spacing: -0.03em;
+            margin-bottom: 1rem;
+        }
+
+        .page-header h1 .accent {
+            color: var(--accent-purple);
+        }
+
+        .page-header .lead {
+            font-size: clamp(1rem, 2vw, 1.15rem);
+            color: var(--text-secondary);
+            max-width: 580px;
+            margin: 0 auto;
+            line-height: 1.7;
+        }
+
+        /* ===== TABLE OF CONTENTS ===== */
+        .toc {
+            position: relative;
+            z-index: 1;
+            max-width: 640px;
+            margin: 0 auto 2rem;
+            padding: 0 2rem;
+        }
+
+        .toc-inner {
+            background: var(--bg-dark-lighter);
+            border: 1px solid rgba(84, 91, 254, 0.15);
+            border-radius: 14px;
+            padding: 1.5rem 2rem;
+        }
+
+        .toc-title {
+            font-size: 0.8rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            color: var(--text-muted);
+            margin-bottom: 0.8rem;
+        }
+
+        .toc-list {
+            list-style: none;
+            display: grid;
+            gap: 0.35rem;
+        }
+
+        .toc-list li {
+            display: flex;
+            align-items: baseline;
+            gap: 0.65rem;
+        }
+
+        .toc-number {
+            font-family: var(--font-mono);
+            font-size: 0.75rem;
+            font-weight: 700;
+            color: var(--accent-purple);
+            min-width: 1.5rem;
+        }
+
+        .toc-list a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            font-size: 0.92rem;
+            font-weight: 500;
+            transition: color 0.2s;
+            line-height: 1.6;
+        }
+
+        .toc-list a:hover { color: var(--accent-purple); }
+
+        /* ===== TUTORIAL SECTIONS ===== */
+        .tutorial-section {
+            position: relative;
+            z-index: 1;
+            max-width: 760px;
+            margin: 0 auto;
+            padding: 3rem 2rem 3.5rem;
+        }
+
+        .tutorial-section::before {
+            content: '';
+            position: absolute;
+            top: 0; left: 2rem; right: 2rem;
+            height: 1px;
+            background: linear-gradient(90deg, transparent, rgba(84, 91, 254, 0.2), transparent);
+        }
+
+        .section-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.6rem;
+            margin-bottom: 1rem;
+        }
+
+        .section-number {
+            width: 36px; height: 36px;
+            background: var(--accent-purple);
+            color: #fff;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 800;
+            font-size: 0.95rem;
+            box-shadow: 0 2px 12px var(--accent-purple-glow);
+            flex-shrink: 0;
+        }
+
+        .section-label {
+            font-size: 0.75rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            color: var(--accent-purple);
+        }
+
+        .tutorial-section h2 {
+            font-size: clamp(1.5rem, 3.5vw, 2rem);
+            font-weight: 800;
+            letter-spacing: -0.02em;
+            margin-bottom: 1rem;
+            line-height: 1.2;
+        }
+
+        .tutorial-section p {
+            font-size: 1rem;
+            color: var(--text-secondary);
+            line-height: 1.75;
+            margin-bottom: 1rem;
+        }
+
+        .tutorial-section p:last-child { margin-bottom: 0; }
+
+        .tutorial-section strong {
+            color: var(--text-primary);
+            font-weight: 600;
+        }
+
+        .tutorial-section a {
+            color: var(--accent-purple);
+            text-decoration: none;
+            font-weight: 500;
+            border-bottom: 1px solid rgba(84, 91, 254, 0.3);
+            transition: border-color 0.2s;
+        }
+
+        .tutorial-section a:hover { border-color: var(--accent-purple); }
+
+        /* ===== CHECKLIST ===== */
+        .checklist {
+            list-style: none;
+            margin: 1rem 0 1.2rem;
+            display: grid;
+            gap: 0.5rem;
+        }
+
+        .checklist li {
+            display: flex;
+            align-items: flex-start;
+            gap: 0.7rem;
+            font-size: 0.95rem;
+            color: var(--text-secondary);
+            line-height: 1.6;
+        }
+
+        .checklist li::before {
+            content: '';
+            flex-shrink: 0;
+            width: 20px; height: 20px;
+            margin-top: 2px;
+            border-radius: 6px;
+            border: 2px solid var(--accent-green);
+            background: rgba(46, 194, 113, 0.08);
+            background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4 8.5L6.5 11L12 5' stroke='%232ec271' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+            background-position: center;
+            background-repeat: no-repeat;
+            background-size: 14px;
+        }
+
+        /* ===== CODE BLOCKS ===== */
+        .code-block {
+            background: var(--code-bg);
+            border: 1px solid rgba(84, 91, 254, 0.15);
+            border-radius: 10px;
+            padding: 1rem 1.2rem;
+            margin: 1rem 0 1.2rem;
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+        }
+
+        .code-block code {
+            font-family: var(--font-mono);
+            font-size: 0.82rem;
+            color: #c5cae8;
+            white-space: pre;
+            line-height: 1.6;
+        }
+
+        .code-block code .token-flag { color: var(--accent-green); }
+        .code-block code .token-url { color: #88a4e6; }
+        .code-block code .token-arg { color: #ffa657; }
+        .code-block code .token-comment { color: var(--text-muted); font-style: italic; }
+        .code-block code .token-env { color: #d4a0ff; }
+        .code-block code .token-cmd { color: #7dd3fc; }
+
+        .code-label {
+            font-size: 0.72rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+        }
+
+        /* ===== CALLOUT BOXES ===== */
+        .callout {
+            border-radius: 10px;
+            padding: 1rem 1.2rem;
+            margin: 1rem 0 1.2rem;
+            font-size: 0.92rem;
+            line-height: 1.65;
+        }
+
+        .callout p { font-size: 0.92rem; margin-bottom: 0; }
+
+        .callout-tip {
+            background: rgba(46, 194, 113, 0.08);
+            border: 1px solid rgba(46, 194, 113, 0.2);
+            color: var(--text-secondary);
+        }
+
+        .callout-tip .callout-label {
+            color: var(--accent-green);
+            font-weight: 700;
+            font-size: 0.78rem;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            margin-bottom: 0.3rem;
+        }
+
+        .callout-info {
+            background: rgba(84, 91, 254, 0.06);
+            border: 1px solid rgba(84, 91, 254, 0.18);
+            color: var(--text-secondary);
+        }
+
+        .callout-info .callout-label {
+            color: var(--accent-purple);
+            font-weight: 700;
+            font-size: 0.78rem;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            margin-bottom: 0.3rem;
+        }
+
+        /* ===== CLI REFERENCE TABLE ===== */
+        .cli-ref {
+            margin: 1rem 0 1.2rem;
+            display: grid;
+            gap: 0.6rem;
+        }
+
+        .cli-ref-item {
+            background: var(--bg-dark-lighter);
+            border: 1px solid rgba(84, 91, 254, 0.1);
+            border-radius: 10px;
+            padding: 1rem 1.2rem;
+            transition: border-color 0.2s;
+        }
+
+        .cli-ref-item:hover {
+            border-color: rgba(84, 91, 254, 0.25);
+        }
+
+        .cli-ref-flags {
+            font-family: var(--font-mono);
+            font-size: 0.85rem;
+            color: var(--accent-green);
+            font-weight: 600;
+            margin-bottom: 0.25rem;
+        }
+
+        .cli-ref-desc {
+            font-size: 0.88rem;
+            color: var(--text-secondary);
+            line-height: 1.55;
+        }
+
+        .cli-ref-meta {
+            font-size: 0.78rem;
+            color: var(--text-muted);
+            margin-top: 0.25rem;
+        }
+
+        .cli-ref-meta code {
+            font-family: var(--font-mono);
+            font-size: 0.75rem;
+            background: var(--code-bg);
+            padding: 0.1rem 0.4rem;
+            border-radius: 4px;
+            color: #d4a0ff;
+        }
+
+        .tag {
+            display: inline-block;
+            font-size: 0.68rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            padding: 0.15rem 0.5rem;
+            border-radius: 4px;
+            margin-left: 0.5rem;
+            vertical-align: middle;
+        }
+
+        .tag-required {
+            background: rgba(232, 72, 85, 0.12);
+            color: var(--accent-red);
+        }
+
+        .tag-default {
+            background: rgba(84, 91, 254, 0.1);
+            color: var(--accent-purple);
+        }
+
+        /* Inline code */
+        .tutorial-section :not(pre) > code,
+        .callout code,
+        .checklist code {
+            font-family: var(--font-mono);
+            font-size: 0.85em;
+            background: var(--code-bg);
+            padding: 0.15rem 0.45rem;
+            border-radius: 5px;
+            color: #c5cae8;
+            border: 1px solid rgba(84, 91, 254, 0.1);
+        }
+
+        /* ===== FOOTER ===== */
+        footer {
+            position: relative;
+            z-index: 1;
+            text-align: center;
+            padding: 2.5rem 2rem;
+            border-top: 1px solid rgba(255,255,255,0.06);
+        }
+
+        .footer-links {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 1.5rem;
+            flex-wrap: wrap;
+            margin-bottom: 0.8rem;
+        }
+
+        .footer-links a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            font-size: 0.9rem;
+            font-weight: 500;
+            transition: color 0.2s;
+        }
+
+        .footer-links a:hover { color: var(--accent-purple); }
+
+        .footer-links .sep {
+            width: 4px; height: 4px;
+            background: var(--text-muted);
+            border-radius: 50%;
+            display: inline-block;
+        }
+
+        .footer-tagline {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        /* ===== ANIMATIONS ===== */
+        @keyframes fadeInUp {
+            from { opacity: 0; transform: translateY(24px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+
+        .page-header-content { animation: fadeInUp 0.7s ease-out both; }
+        .toc-inner { animation: fadeInUp 0.6s ease-out 0.15s both; }
+
+        .tutorial-section:nth-of-type(1) { animation: fadeInUp 0.5s ease-out 0.05s both; }
+        .tutorial-section:nth-of-type(2) { animation: fadeInUp 0.5s ease-out 0.1s both; }
+        .tutorial-section:nth-of-type(3) { animation: fadeInUp 0.5s ease-out 0.15s both; }
+        .tutorial-section:nth-of-type(4) { animation: fadeInUp 0.5s ease-out 0.2s both; }
+        .tutorial-section:nth-of-type(5) { animation: fadeInUp 0.5s ease-out 0.25s both; }
+
+        /* ===== RESPONSIVE ===== */
+        @media (max-width: 768px) {
+            .page-header { padding: 4rem 1.5rem 2.5rem; }
+            .tutorial-section { padding: 2.5rem 1.5rem 3rem; }
+            .toc { padding: 0 1.5rem; }
+            .top-nav { padding: 0.75rem 1.25rem; }
+        }
+
+        @media (max-width: 480px) {
+            .page-header h1 { font-size: 1.7rem; }
+            .tutorial-section h2 { font-size: 1.3rem; }
+            .code-block { padding: 0.8rem; }
+            .code-block code { font-size: 0.75rem; }
+            .cli-ref-item { padding: 0.8rem; }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            *, *::before, *::after {
+                animation-duration: 0.01ms !important;
+                animation-delay: 0.01ms !important;
+            }
+            .nav-back:hover svg { transform: none; }
+        }
+    </style>
+</head>
+<body>
+
+    <!-- ===== TOP NAV ===== -->
+    <nav class="top-nav" aria-label="Page navigation">
+        <a href="usage.html" class="nav-back">
+            <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M10.5 3L5.5 8l5 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>
+            Back to Usage Guide
+        </a>
+        <a href="https://github.com/ZzAve/ynab-split-payee-and-memo" class="nav-github" target="_blank" rel="noopener">
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+            GitHub
+        </a>
+    </nav>
+
+    <!-- ===== PAGE HEADER ===== -->
+    <header class="page-header">
+        <div class="page-header-content">
+            <h1>Run in the <span class="accent">cloud</span></h1>
+            <p class="lead">
+                No laptop required &mdash; run the splitter on a schedule
+                with Scaleway Serverless Jobs.
+            </p>
+        </div>
+    </header>
+
+    <!-- ===== TABLE OF CONTENTS ===== -->
+    <nav class="toc" aria-label="Table of contents">
+        <div class="toc-inner">
+            <div class="toc-title">In this guide</div>
+            <ol class="toc-list">
+                <li><span class="toc-number">01</span><a href="#prerequisites">Prerequisites</a></li>
+                <li><span class="toc-number">02</span><a href="#create-job">Create the job</a></li>
+                <li><span class="toc-number">03</span><a href="#env-vars">Environment variables</a></li>
+                <li><span class="toc-number">04</span><a href="#cron-trigger">Cron trigger</a></li>
+                <li><span class="toc-number">05</span><a href="#verify">Verify</a></li>
+            </ol>
+        </div>
+    </nav>
+
+    <!-- ===== SECTION 1: PREREQUISITES ===== -->
+    <section class="tutorial-section" id="prerequisites" aria-labelledby="prerequisites-heading">
+        <div class="section-badge">
+            <div class="section-number" aria-hidden="true">1</div>
+            <span class="section-label">Getting ready</span>
+        </div>
+        <h2 id="prerequisites-heading">Prerequisites</h2>
+        <p>
+            Before you start, make sure you have these two things in place.
+        </p>
+
+        <ul class="checklist" role="list">
+            <li>A <strong>Scaleway account</strong> with a project in the Paris or Amsterdam region.</li>
+            <li>A <strong>YNAB Personal Access Token</strong>. If you don't have one yet, see <a href="usage.html#prerequisites">the usage guide</a> for how to create it.</li>
+        </ul>
+    </section>
+
+    <!-- ===== SECTION 2: CREATE THE JOB ===== -->
+    <section class="tutorial-section" id="create-job" aria-labelledby="create-job-heading">
+        <div class="section-badge">
+            <div class="section-number" aria-hidden="true">2</div>
+            <span class="section-label">Set it up</span>
+        </div>
+        <h2 id="create-job-heading">Create the job</h2>
+        <p>
+            In the Scaleway Console, navigate to <strong>Serverless &rarr; Jobs</strong> and create a new job definition.
+        </p>
+        <p>
+            Set the image source to the public Docker image:
+        </p>
+
+        <p class="code-label">Image reference</p>
+        <div class="code-block"><code><span class="token-url">docker.io/zzave/ynab-split-payee:latest</span></code></div>
+
+        <p>
+            For resources, <strong>1 vCPU</strong> and <strong>256 MB RAM</strong> is more than enough.
+            The job typically finishes in a few seconds.
+        </p>
+    </section>
+
+    <!-- ===== SECTION 3: ENVIRONMENT VARIABLES ===== -->
+    <section class="tutorial-section" id="env-vars" aria-labelledby="env-vars-heading">
+        <div class="section-badge">
+            <div class="section-number" aria-hidden="true">3</div>
+            <span class="section-label">Configure</span>
+        </div>
+        <h2 id="env-vars-heading">Environment variables</h2>
+        <p>
+            Add the following environment variables to your job definition.
+            Only the token is required &mdash; the rest are optional.
+        </p>
+
+        <div class="cli-ref" role="list">
+            <div class="cli-ref-item" role="listitem">
+                <div class="cli-ref-flags">YNAB_TOKEN <span class="tag tag-required">Required</span></div>
+                <div class="cli-ref-desc">Your YNAB Personal Access Token. This is how the tool authenticates with the YNAB API.</div>
+            </div>
+
+            <div class="cli-ref-item" role="listitem">
+                <div class="cli-ref-flags">YNAB_BUDGET_ID</div>
+                <div class="cli-ref-desc">Target a specific YNAB budget. If omitted, the tool uses your last-used budget.</div>
+            </div>
+
+            <div class="cli-ref-item" role="listitem">
+                <div class="cli-ref-flags">YNAB_ACCOUNT_ID</div>
+                <div class="cli-ref-desc">Only process transactions from a specific account. If omitted, all accounts are processed.</div>
+            </div>
+
+            <div class="cli-ref-item" role="listitem">
+                <div class="cli-ref-flags">YNAB_BUDGET_IDS</div>
+                <div class="cli-ref-desc">Comma-separated list of budget IDs to process multiple budgets in one run. Cannot be used with <code>YNAB_BUDGET_ID</code>.</div>
+            </div>
+        </div>
+
+        <div class="callout callout-tip" role="note">
+            <div class="callout-label">Tip</div>
+            <p>
+                Use Scaleway's <strong>secret management</strong> to store your YNAB token
+                rather than adding it as a plain-text environment variable.
+            </p>
+        </div>
+    </section>
+
+    <!-- ===== SECTION 4: CRON TRIGGER ===== -->
+    <section class="tutorial-section" id="cron-trigger" aria-labelledby="cron-trigger-heading">
+        <div class="section-badge">
+            <div class="section-number" aria-hidden="true">4</div>
+            <span class="section-label">Schedule</span>
+        </div>
+        <h2 id="cron-trigger-heading">Cron trigger</h2>
+        <p>
+            Add a cron trigger to your job so it runs automatically.
+            Every hour is a good default &mdash; frequent enough to catch new imports quickly,
+            light enough to stay well within free-tier limits.
+        </p>
+
+        <p class="code-label">Cron expression (every hour)</p>
+        <div class="code-block"><code><span class="token-arg">0 * * * *</span></code></div>
+
+        <div class="callout callout-info" role="note">
+            <div class="callout-label">Note</div>
+            <p>
+                Scaleway cron triggers use <strong>UTC</strong>.
+                If you'd rather run it at a specific local time (e.g. every morning at 8 AM),
+                adjust the hour accordingly.
+            </p>
+        </div>
+    </section>
+
+    <!-- ===== SECTION 5: VERIFY ===== -->
+    <section class="tutorial-section" id="verify" aria-labelledby="verify-heading">
+        <div class="section-badge">
+            <div class="section-number" aria-hidden="true">5</div>
+            <span class="section-label">Confirm</span>
+        </div>
+        <h2 id="verify-heading">Verify</h2>
+        <p>
+            Before relying on the schedule, trigger a manual run from the Scaleway console
+            to make sure everything is wired up correctly.
+        </p>
+
+        <ul class="checklist" role="list">
+            <li><strong>Trigger a manual run</strong> from the job detail page in the Scaleway console.</li>
+            <li><strong>Check the run log</strong> for exit code 0. If you see errors, double-check your token and environment variables.</li>
+            <li><strong>Open YNAB</strong> and confirm that your transactions were processed &mdash; payees should be clean, memos filled in.</li>
+        </ul>
+
+        <p>
+            Once the manual run looks good, the cron trigger will take care of the rest.
+            Your transactions will be cleaned up automatically, whether your laptop is on or not.
+        </p>
+    </section>
+
+    <!-- ===== FOOTER ===== -->
+    <footer>
+        <div class="footer-links">
+            <a href="index.html">Home</a>
+            <span class="sep" aria-hidden="true"></span>
+            <a href="usage.html">Usage Guide</a>
+            <span class="sep" aria-hidden="true"></span>
+            <a href="https://github.com/ZzAve/ynab-split-payee-and-memo" target="_blank" rel="noopener">GitHub</a>
+            <span class="sep" aria-hidden="true"></span>
+            <a href="https://github.com/ZzAve/ynab-split-payee-and-memo/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
+        </div>
+        <p class="footer-tagline">Made with &#9749; and frustration at messy payees</p>
+    </footer>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -870,6 +870,8 @@
         <div class="footer-links">
             <a href="usage.html">Usage Guide</a>
             <span class="sep" aria-hidden="true"></span>
+            <a href="cloud.html">Cloud Setup</a>
+            <span class="sep" aria-hidden="true"></span>
             <a href="https://github.com/ZzAve/ynab-split-payee-and-memo" target="_blank" rel="noopener">GitHub</a>
             <span class="sep" aria-hidden="true"></span>
             <a href="https://github.com/ZzAve/ynab-split-payee-and-memo/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -854,6 +854,15 @@
             </p>
         </div>
 
+        <div class="callout callout-info" role="note">
+            <div class="callout-label">Running in the cloud?</div>
+            <p>
+                Skip the local cron setup and run this as a managed job instead.
+                See the <a href="cloud.html">Scaleway Serverless Jobs guide</a>
+                for a hands-off setup that runs whether your laptop is on or not.
+            </p>
+        </div>
+
         <p>
             For detailed platform-specific instructions (including macOS-specific tips and how to disable the job later),
             see the <a href="https://github.com/ZzAve/ynab-split-payee-and-memo#setting-up-a-cron-job-on-macos" target="_blank" rel="noopener">full cron setup guide</a> in the README.

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -938,6 +938,8 @@
         <div class="footer-links">
             <a href="index.html">Home</a>
             <span class="sep" aria-hidden="true"></span>
+            <a href="cloud.html">Cloud Setup</a>
+            <span class="sep" aria-hidden="true"></span>
             <a href="https://github.com/ZzAve/ynab-split-payee-and-memo" target="_blank" rel="noopener">GitHub</a>
             <span class="sep" aria-hidden="true"></span>
             <a href="https://github.com/ZzAve/ynab-split-payee-and-memo/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -623,9 +623,9 @@
         </p>
 
         <ul class="checklist" role="list">
-            <li>A <strong>YNAB account</strong> with at least one linked bank account (direct import). That's where the messy payee descriptions come from.</li>
-            <li>A <strong>YNAB Personal Access Token</strong>. This is how the tool talks to your budget.</li>
-            <li><strong>Docker</strong> installed and running on your machine. (If you prefer, Java 21+ works too &mdash; but Docker is the easy path.)</li>
+            <li><span>A <strong>YNAB account</strong> with at least one linked bank account (direct import). That's where the messy payee descriptions come from.</span></li>
+            <li><span>A <strong>YNAB Personal Access Token</strong>. This is how the tool talks to your budget.</span></li>
+            <li><span><strong>Docker</strong> installed and running on your machine. (If you prefer, Java 21+ works too &mdash; but Docker is the easy path.)</span></li>
         </ul>
 
         <h3 style="font-size: 1.1rem; font-weight: 700; margin: 1.5rem 0 0.6rem; color: var(--text-primary);">Getting your YNAB token</h3>


### PR DESCRIPTION
## Summary
- Add `docs/cloud.html` — a tutorial page for running the splitter as a scheduled Scaleway Serverless Job
- Add cross-link callout in `docs/usage.html` Section 5 pointing to the cloud guide
- Add "Cloud Setup" link to footer navigation on index.html and usage.html
- Fix checklist text flow on both pages by wrapping li content in span elements

## Test plan
- [x] Open `docs/cloud.html` — all 5 sections render, TOC links scroll correctly
- [x] Open `docs/usage.html` — Section 5 shows "Running in the cloud?" callout with working link
- [x] Footer links on all three pages include "Cloud Setup" and navigate correctly
- [x] Checklist items flow as natural prose (no table-like layout)
- [x] Responsive layout works on narrow viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)