### PR TITLE
refactor(docs): extract shared CSS into styles.css

### DIFF
--- a/docs/cloud.html
+++ b/docs/cloud.html
@@ -6,46 +6,8 @@
     <title>Cloud Setup - YNAB Split Payee and Memo</title>
     <meta name="description" content="Run YNAB Split Payee and Memo as a scheduled cloud job with Scaleway Serverless Jobs.">
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Cpath d='M7 10C7 7.2 9.2 5 12 5L26 5 22 59 12 59C9.2 59 7 56.8 7 54Z' fill='%23545bfe' opacity='0.82'/%3E%3Cpath d='M38 5L52 5C54.8 5 57 7.2 57 10V54C57 56.8 54.8 59 52 59L42 59Z' fill='%23545bfe'/%3E%3Crect x='26.5' y='28.5' width='11' height='3.5' rx='1.75' fill='%232ec271'/%3E%3Crect x='11.5' y='16' width='12' height='2' rx='1' fill='%23fff' opacity='0.5'/%3E%3Crect x='11.5' y='22' width='8.5' height='2' rx='1' fill='%23fff' opacity='0.3'/%3E%3Crect x='12' y='36' width='10' height='2' rx='1' fill='%23fff' opacity='0.5'/%3E%3Crect x='12' y='42' width='7' height='2' rx='1' fill='%23fff' opacity='0.3'/%3E%3Crect x='42' y='16' width='11' height='2' rx='1' fill='%23fff' opacity='0.75'/%3E%3Crect x='42' y='22' width='8' height='2' rx='1' fill='%23fff' opacity='0.5'/%3E%3Crect x='42' y='36' width='10' height='2' rx='1' fill='%23fff' opacity='0.75'/%3E%3Crect x='42' y='42' width='6' height='2' rx='1' fill='%23fff' opacity='0.5'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="styles.css">
     <style>
-        /* ===== RESET & BASE ===== */
-        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-        :root {
-            --bg-dark: #181b2e;
-            --bg-dark-lighter: #1e2140;
-            --accent-purple: #545bfe;
-            --accent-purple-glow: rgba(84, 91, 254, 0.25);
-            --accent-green: #2ec271;
-            --accent-green-glow: rgba(46, 194, 113, 0.15);
-            --accent-red: #e84855;
-            --text-primary: #eef0f8;
-            --text-secondary: #a0a5c0;
-            --text-muted: #6b7194;
-            --code-bg: #12142a;
-            --font-stack: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-            --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'JetBrains Mono', Consolas, monospace;
-        }
-
-        body {
-            font-family: var(--font-stack);
-            background-color: var(--bg-dark);
-            color: var(--text-primary);
-            line-height: 1.6;
-            overflow-x: hidden;
-            -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
-        }
-
-        /* ===== NOISE OVERLAY FOR TEXTURE ===== */
-        body::before {
-            content: '';
-            position: fixed;
-            top: 0; left: 0; right: 0; bottom: 0;
-            background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.03'/%3E%3C/svg%3E");
-            pointer-events: none;
-            z-index: 0;
-        }
-
         /* ===== TOP NAV ===== */
         .top-nav {
             position: sticky;
@@ -327,9 +289,6 @@
             line-height: 1.6;
         }
 
-        .code-block code .token-flag { color: var(--accent-green); }
-        .code-block code .token-url { color: #88a4e6; }
-        .code-block code .token-arg { color: #ffa657; }
         .code-block code .token-comment { color: var(--text-muted); font-style: italic; }
         .code-block code .token-env { color: #d4a0ff; }
         .code-block code .token-cmd { color: #7dd3fc; }
@@ -447,52 +406,6 @@
             border: 1px solid rgba(84, 91, 254, 0.1);
         }
 
-        /* ===== FOOTER ===== */
-        footer {
-            position: relative;
-            z-index: 1;
-            text-align: center;
-            padding: 2.5rem 2rem;
-            border-top: 1px solid rgba(255,255,255,0.06);
-        }
-
-        .footer-links {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-            margin-bottom: 0.8rem;
-        }
-
-        .footer-links a {
-            color: var(--text-secondary);
-            text-decoration: none;
-            font-size: 0.9rem;
-            font-weight: 500;
-            transition: color 0.2s;
-        }
-
-        .footer-links a:hover { color: var(--accent-purple); }
-
-        .footer-links .sep {
-            width: 4px; height: 4px;
-            background: var(--text-muted);
-            border-radius: 50%;
-            display: inline-block;
-        }
-
-        .footer-tagline {
-            font-size: 0.85rem;
-            color: var(--text-muted);
-        }
-
-        /* ===== ANIMATIONS ===== */
-        @keyframes fadeInUp {
-            from { opacity: 0; transform: translateY(24px); }
-            to { opacity: 1; transform: translateY(0); }
-        }
-
         .page-header-content { animation: fadeInUp 0.7s ease-out both; }
         .toc-inner { animation: fadeInUp 0.6s ease-out 0.15s both; }
 
@@ -519,10 +432,6 @@
         }
 
         @media (prefers-reduced-motion: reduce) {
-            *, *::before, *::after {
-                animation-duration: 0.01ms !important;
-                animation-delay: 0.01ms !important;
-            }
             .nav-back:hover svg { transform: none; }
         }
     </style>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,53 +6,8 @@
     <title>YNAB Split Payee and Memo</title>
     <meta name="description" content="Automatically split messy YNAB transaction payees into clean Payee and Memo fields.">
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Cpath d='M7 10C7 7.2 9.2 5 12 5L26 5 22 59 12 59C9.2 59 7 56.8 7 54Z' fill='%23545bfe' opacity='0.82'/%3E%3Cpath d='M38 5L52 5C54.8 5 57 7.2 57 10V54C57 56.8 54.8 59 52 59L42 59Z' fill='%23545bfe'/%3E%3Crect x='26.5' y='28.5' width='11' height='3.5' rx='1.75' fill='%232ec271'/%3E%3Crect x='11.5' y='16' width='12' height='2' rx='1' fill='%23fff' opacity='0.5'/%3E%3Crect x='11.5' y='22' width='8.5' height='2' rx='1' fill='%23fff' opacity='0.3'/%3E%3Crect x='12' y='36' width='10' height='2' rx='1' fill='%23fff' opacity='0.5'/%3E%3Crect x='12' y='42' width='7' height='2' rx='1' fill='%23fff' opacity='0.3'/%3E%3Crect x='42' y='16' width='11' height='2' rx='1' fill='%23fff' opacity='0.75'/%3E%3Crect x='42' y='22' width='8' height='2' rx='1' fill='%23fff' opacity='0.5'/%3E%3Crect x='42' y='36' width='10' height='2' rx='1' fill='%23fff' opacity='0.75'/%3E%3Crect x='42' y='42' width='6' height='2' rx='1' fill='%23fff' opacity='0.5'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="styles.css">
     <style>
-        /* ===== RESET & BASE ===== */
-        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-        :root {
-            --bg-dark: #181b2e;
-            --bg-dark-lighter: #1e2140;
-            --accent-purple: #545bfe;
-            --accent-purple-glow: rgba(84, 91, 254, 0.25);
-            --accent-green: #2ec271;
-            --accent-green-glow: rgba(46, 194, 113, 0.15);
-            --accent-red: #e84855;
-            --text-primary: #eef0f8;
-            --text-secondary: #a0a5c0;
-            --text-muted: #6b7194;
-            --ynab-cream: #fef9ed;
-            --ynab-cream-alt: #fdf5e2;
-            --ynab-navy: #1c1f58;
-            --ynab-navy-light: #292d6b;
-            --ynab-border: #e8dcc8;
-            --ynab-text: #3a3352;
-            --ynab-text-light: #8e87a0;
-            --code-bg: #12142a;
-            --font-stack: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-            --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'JetBrains Mono', Consolas, monospace;
-        }
-
-        body {
-            font-family: var(--font-stack);
-            background-color: var(--bg-dark);
-            color: var(--text-primary);
-            line-height: 1.6;
-            overflow-x: hidden;
-            -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
-        }
-
-        /* ===== NOISE OVERLAY FOR TEXTURE ===== */
-        body::before {
-            content: '';
-            position: fixed;
-            top: 0; left: 0; right: 0; bottom: 0;
-            background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.03'/%3E%3C/svg%3E");
-            pointer-events: none;
-            z-index: 0;
-        }
-
         /* ===== SECTION WRAPPER ===== */
         .section { position: relative; z-index: 1; }
 
@@ -439,50 +394,6 @@
             line-height: 1.5;
         }
 
-        .code-block code .token-flag { color: var(--accent-green); }
-        .code-block code .token-url { color: #88a4e6; }
-        .code-block code .token-arg { color: #ffa657; }
-
-        /* ===== FOOTER ===== */
-        footer {
-            position: relative;
-            z-index: 1;
-            text-align: center;
-            padding: 2.5rem 2rem;
-            border-top: 1px solid rgba(255,255,255,0.06);
-        }
-
-        .footer-links {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-            margin-bottom: 0.8rem;
-        }
-
-        .footer-links a {
-            color: var(--text-secondary);
-            text-decoration: none;
-            font-size: 0.9rem;
-            font-weight: 500;
-            transition: color 0.2s;
-        }
-
-        .footer-links a:hover { color: var(--accent-purple); }
-
-        .footer-links .sep {
-            width: 4px; height: 4px;
-            background: var(--text-muted);
-            border-radius: 50%;
-            display: inline-block;
-        }
-
-        .footer-tagline {
-            font-size: 0.85rem;
-            color: var(--text-muted);
-        }
-
         /* ===== TOP NAV ===== */
         .top-nav {
             position: absolute;
@@ -563,12 +474,6 @@
             to { opacity: 1; transform: translateY(0) scale(1); }
         }
 
-        /* ===== ANIMATIONS ===== */
-        @keyframes fadeInUp {
-            from { opacity: 0; transform: translateY(24px); }
-            to { opacity: 1; transform: translateY(0); }
-        }
-
         .hero-content { animation: fadeInUp 0.7s ease-out both; }
         .hero .subtitle { animation: fadeInUp 0.7s ease-out 0.15s both; }
         .cta-btn { animation: fadeInUp 0.7s ease-out 0.3s both; }
@@ -623,12 +528,6 @@
             }
         }
 
-        @media (prefers-reduced-motion: reduce) {
-            *, *::before, *::after {
-                animation-duration: 0.01ms !important;
-                animation-delay: 0.01ms !important;
-            }
-        }
     </style>
 </head>
 <body>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,104 @@
+/* ===== RESET & BASE ===== */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+    --bg-dark: #181b2e;
+    --bg-dark-lighter: #1e2140;
+    --accent-purple: #545bfe;
+    --accent-purple-glow: rgba(84, 91, 254, 0.25);
+    --accent-green: #2ec271;
+    --accent-green-glow: rgba(46, 194, 113, 0.15);
+    --accent-red: #e84855;
+    --text-primary: #eef0f8;
+    --text-secondary: #a0a5c0;
+    --text-muted: #6b7194;
+    --ynab-cream: #fef9ed;
+    --ynab-cream-alt: #fdf5e2;
+    --ynab-navy: #1c1f58;
+    --ynab-navy-light: #292d6b;
+    --ynab-border: #e8dcc8;
+    --ynab-text: #3a3352;
+    --ynab-text-light: #8e87a0;
+    --code-bg: #12142a;
+    --font-stack: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'JetBrains Mono', Consolas, monospace;
+}
+
+body {
+    font-family: var(--font-stack);
+    background-color: var(--bg-dark);
+    color: var(--text-primary);
+    line-height: 1.6;
+    overflow-x: hidden;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+/* ===== NOISE OVERLAY FOR TEXTURE ===== */
+body::before {
+    content: '';
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.03'/%3E%3C/svg%3E");
+    pointer-events: none;
+    z-index: 0;
+}
+
+/* ===== CODE BLOCK TOKENS ===== */
+.code-block code .token-flag { color: var(--accent-green); }
+.code-block code .token-url { color: #88a4e6; }
+.code-block code .token-arg { color: #ffa657; }
+
+/* ===== FOOTER ===== */
+footer {
+    position: relative;
+    z-index: 1;
+    text-align: center;
+    padding: 2.5rem 2rem;
+    border-top: 1px solid rgba(255,255,255,0.06);
+}
+
+.footer-links {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.8rem;
+}
+
+.footer-links a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: 0.9rem;
+    font-weight: 500;
+    transition: color 0.2s;
+}
+
+.footer-links a:hover { color: var(--accent-purple); }
+
+.footer-links .sep {
+    width: 4px; height: 4px;
+    background: var(--text-muted);
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.footer-tagline {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+/* ===== ANIMATIONS ===== */
+@keyframes fadeInUp {
+    from { opacity: 0; transform: translateY(24px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+/* ===== ACCESSIBILITY ===== */
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-delay: 0.01ms !important;
+    }
+}

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -6,53 +6,8 @@
     <title>Usage Guide - YNAB Split Payee and Memo</title>
     <meta name="description" content="Step-by-step tutorial for using YNAB Split Payee and Memo to clean up your imported transactions.">
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Cpath d='M7 10C7 7.2 9.2 5 12 5L26 5 22 59 12 59C9.2 59 7 56.8 7 54Z' fill='%23545bfe' opacity='0.82'/%3E%3Cpath d='M38 5L52 5C54.8 5 57 7.2 57 10V54C57 56.8 54.8 59 52 59L42 59Z' fill='%23545bfe'/%3E%3Crect x='26.5' y='28.5' width='11' height='3.5' rx='1.75' fill='%232ec271'/%3E%3Crect x='11.5' y='16' width='12' height='2' rx='1' fill='%23fff' opacity='0.5'/%3E%3Crect x='11.5' y='22' width='8.5' height='2' rx='1' fill='%23fff' opacity='0.3'/%3E%3Crect x='12' y='36' width='10' height='2' rx='1' fill='%23fff' opacity='0.5'/%3E%3Crect x='12' y='42' width='7' height='2' rx='1' fill='%23fff' opacity='0.3'/%3E%3Crect x='42' y='16' width='11' height='2' rx='1' fill='%23fff' opacity='0.75'/%3E%3Crect x='42' y='22' width='8' height='2' rx='1' fill='%23fff' opacity='0.5'/%3E%3Crect x='42' y='36' width='10' height='2' rx='1' fill='%23fff' opacity='0.75'/%3E%3Crect x='42' y='42' width='6' height='2' rx='1' fill='%23fff' opacity='0.5'/%3E%3C/svg%3E">
+    <link rel="stylesheet" href="styles.css">
     <style>
-        /* ===== RESET & BASE ===== */
-        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-        :root {
-            --bg-dark: #181b2e;
-            --bg-dark-lighter: #1e2140;
-            --accent-purple: #545bfe;
-            --accent-purple-glow: rgba(84, 91, 254, 0.25);
-            --accent-green: #2ec271;
-            --accent-green-glow: rgba(46, 194, 113, 0.15);
-            --accent-red: #e84855;
-            --text-primary: #eef0f8;
-            --text-secondary: #a0a5c0;
-            --text-muted: #6b7194;
-            --ynab-cream: #fef9ed;
-            --ynab-cream-alt: #fdf5e2;
-            --ynab-navy: #1c1f58;
-            --ynab-navy-light: #292d6b;
-            --ynab-border: #e8dcc8;
-            --ynab-text: #3a3352;
-            --ynab-text-light: #8e87a0;
-            --code-bg: #12142a;
-            --font-stack: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-            --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'JetBrains Mono', Consolas, monospace;
-        }
-
-        body {
-            font-family: var(--font-stack);
-            background-color: var(--bg-dark);
-            color: var(--text-primary);
-            line-height: 1.6;
-            overflow-x: hidden;
-            -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
-        }
-
-        /* ===== NOISE OVERLAY FOR TEXTURE ===== */
-        body::before {
-            content: '';
-            position: fixed;
-            top: 0; left: 0; right: 0; bottom: 0;
-            background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.03'/%3E%3C/svg%3E");
-            pointer-events: none;
-            z-index: 0;
-        }
-
         /* ===== TOP NAV ===== */
         .top-nav {
             position: sticky;
@@ -334,9 +289,6 @@
             line-height: 1.6;
         }
 
-        .code-block code .token-flag { color: var(--accent-green); }
-        .code-block code .token-url { color: #88a4e6; }
-        .code-block code .token-arg { color: #ffa657; }
         .code-block code .token-comment { color: var(--text-muted); font-style: italic; }
         .code-block code .token-env { color: #d4a0ff; }
         .code-block code .token-cmd { color: #7dd3fc; }
@@ -489,52 +441,6 @@
             border: 1px solid rgba(84, 91, 254, 0.1);
         }
 
-        /* ===== FOOTER ===== */
-        footer {
-            position: relative;
-            z-index: 1;
-            text-align: center;
-            padding: 2.5rem 2rem;
-            border-top: 1px solid rgba(255,255,255,0.06);
-        }
-
-        .footer-links {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-            margin-bottom: 0.8rem;
-        }
-
-        .footer-links a {
-            color: var(--text-secondary);
-            text-decoration: none;
-            font-size: 0.9rem;
-            font-weight: 500;
-            transition: color 0.2s;
-        }
-
-        .footer-links a:hover { color: var(--accent-purple); }
-
-        .footer-links .sep {
-            width: 4px; height: 4px;
-            background: var(--text-muted);
-            border-radius: 50%;
-            display: inline-block;
-        }
-
-        .footer-tagline {
-            font-size: 0.85rem;
-            color: var(--text-muted);
-        }
-
-        /* ===== ANIMATIONS ===== */
-        @keyframes fadeInUp {
-            from { opacity: 0; transform: translateY(24px); }
-            to { opacity: 1; transform: translateY(0); }
-        }
-
         .page-header-content { animation: fadeInUp 0.7s ease-out both; }
         .toc-inner { animation: fadeInUp 0.6s ease-out 0.15s both; }
 
@@ -562,10 +468,6 @@
         }
 
         @media (prefers-reduced-motion: reduce) {
-            *, *::before, *::after {
-                animation-duration: 0.01ms !important;
-                animation-delay: 0.01ms !important;
-            }
             .nav-back:hover svg { transform: none; }
         }
     </style>


### PR DESCRIPTION
## Summary
- Extract ~90 lines of duplicated CSS from `index.html`, `usage.html`, and `cloud.html` into a shared `docs/styles.css`
- Shared styles include: reset, CSS variables, body/noise overlay, footer, `fadeInUp` keyframe, `prefers-reduced-motion` base rule, and code token colors
- Each page retains only its page-specific styles inline

## Test plan
- [ ] Open each page locally and verify no visual changes
- [ ] Check that animations, footer, code blocks, and reduced-motion all still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)